### PR TITLE
Fix name of macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,9 +117,9 @@ endif(USE_VC)
 
 # set compiler options =========================================================
 if(DIAG)
-  # Library for time measurement: OSx and Linux
+  # Library for time measurement: macOS and Linux
   set (LIBTIMING "rt")
-  # do not set it if on OSx
+  # do not set it if on macOS
   if (APPLE AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
     set (LIBTIMINGAPPLE "-framework Carbon")
   endif ()

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -62,7 +62,7 @@ o Fixed the installation of atan2.h
 
 V0.2.2
 o Removed typos in the documentation (thanks to A. Neumann for spotting this!)
-o Fixed CMake to make the install working also on OSx
+o Fixed CMake to make the install working also on macOS
 
 V0.2.1
 o Shared library built by default instead of static one.


### PR DESCRIPTION
The Macintosh operating system is now known as "macOS".