### PR TITLE
Python Usage Fixes, master branch (2018.10.23.)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,18 @@
 # Auto generate the code for the vector signatures and if needed preload
 
+# We need Python for the following.
+find_package (PythonInterp REQUIRED)
+
 # Generate the code for the lib
 if (PRELOAD)
 set (SIGGENOPTS  " -p")
 else()
 set (SIGGENOPTS  " ")
 endif()
-EXEC_PROGRAM ("cd src;python ${CMAKE_SOURCE_DIR}/src/signatures_generator.py ${SIGGENOPTS} -o ${CMAKE_SOURCE_DIR}/src;cd -")
+EXEC_PROGRAM ("cd src;${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/signatures_generator.py ${SIGGENOPTS} -o ${CMAKE_SOURCE_DIR}/src;cd -")
 
 #generare Vc wrapper and config file
 if(USE_VC)
-  EXEC_PROGRAM ("cd src;python vc_wrapper_generator.py;cd -")
+  EXEC_PROGRAM ("cd src;${PYTHON_EXECUTABLE} vc_wrapper_generator.py;cd -")
 endif(USE_VC)
 configure_file( ${INC_DIR}/externalLibcfg.h.cmake ${INC_DIR}/externalLibcfg.h)

--- a/src/numpy_wrapper_generator.py
+++ b/src/numpy_wrapper_generator.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 
 """
 Generates numpy wrapper - both header and .cc file

--- a/src/vc_wrapper_generator.py
+++ b/src/vc_wrapper_generator.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 
 """
 Generates vc wrapper - both header and .cc file


### PR DESCRIPTION
This is to make it possible to build/use VDT with Python **not** installed under `/usr/bin`.

This issue came up in https://sft.its.cern.ch/jira/browse/ROOT-9739 and in https://github.com/root-project/root/pull/2829.

Pinging @dpiparo just to be sure he sees this. 😉