### PR TITLE
[cmake] Allow python3 to be found; fixes newest / future macOS.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Auto generate the code for the vector signatures and if needed preload
 
 # We need Python for the following.
-find_package (PythonInterp REQUIRED)
+find_package (Python COMPONENTS Interpreter REQUIRED)
 
 # Generate the code for the lib
 if (PRELOAD)
@@ -9,10 +9,10 @@ set (SIGGENOPTS  " -p")
 else()
 set (SIGGENOPTS  " ")
 endif()
-EXEC_PROGRAM ("cd src;${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/signatures_generator.py ${SIGGENOPTS} -o ${CMAKE_SOURCE_DIR}/src;cd -")
+EXEC_PROGRAM ("cd src;${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/signatures_generator.py ${SIGGENOPTS} -o ${CMAKE_SOURCE_DIR}/src;cd -")
 
 #generare Vc wrapper and config file
 if(USE_VC)
-  EXEC_PROGRAM ("cd src;${PYTHON_EXECUTABLE} vc_wrapper_generator.py;cd -")
+  EXEC_PROGRAM ("cd src;${Python_EXECUTABLE} vc_wrapper_generator.py;cd -")
 endif(USE_VC)
 configure_file( ${INC_DIR}/externalLibcfg.h.cmake ${INC_DIR}/externalLibcfg.h)


### PR DESCRIPTION
And anyway, find_package (PythonInterp) is deprecated since a long time.