### PR TITLE
CMake: use proper install dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project (Vdt)
 #-------------------------------------------------------------------------------
 # Include the defaults
 include ( CMakeDefaults.txt )
+include ( GNUInstallDirs )
 #-------------------------------------------------------------------------------
 
 # configuration options -- you may change them when running cmake ==============
@@ -214,5 +215,5 @@ INSTALL(FILES
         include/tan.h
         include/vdtcore_common.h
         include/vdtMath.h
-        DESTINATION include/vdt)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vdt)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,7 +20,7 @@ ADD_LIBRARY(vdt ${SRC_DIR}/vdtMath_signatures.cc ${INC_DIR}/vdtMath.h )
 
 # Installation of the lib
 INSTALL(TARGETS vdt  
-        DESTINATION lib)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR})
         
 
 # Build Vc wrapper (without c++11)


### PR DESCRIPTION
On Debian, shared libs belong into `lib/<arch-triplet>/`, e.g. `/usr/lib/x86_64-linux-gnu/`.

This PR fixes this by using [CMake's GNUInstallDirs module](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html), which allows to set the variables via CLI.