### PR TITLE
CMake: add SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VDT Math Library
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
-project (Vdt)
+project (Vdt VERSION 0.4.4)
 
 #-------------------------------------------------------------------------------
 # Include the defaults

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,6 +18,12 @@ endif()
 # The library
 ADD_LIBRARY(vdt ${SRC_DIR}/vdtMath_signatures.cc ${INC_DIR}/vdtMath.h )
 
+# Add SOVERSION to lib
+set_target_properties(vdt
+  PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
+
 # Installation of the lib
 INSTALL(TARGETS vdt  
         DESTINATION lib)


### PR DESCRIPTION
This adds a SOVERSION to vdt by using the first to numbers on the version. This means bumps of the patch number in the version should not add ABI changes, and the version should be bumped in CMake on a new git tag.

This a patch we apply in Debian to keep track of required rebuilds.