### PR TITLE
Reorder expression of better accuracy

### DIFF
--- a/include/sincos.h
+++ b/include/sincos.h
@@ -120,7 +120,7 @@ inline void fast_sincos_m45_45( const double z, double & s, double &c ) {
 
     double zz = z * z;    
     s = z  +  z * zz * get_sin_px(zz);                
-    c = 1.0 - zz * .5 + zz * zz * get_cos_px(zz);
+    c = 1.0 + zz * (-.5 + zz * get_cos_px(zz));
   }
 
 


### PR DESCRIPTION
 I think there is a typo in `sincos.h` that dramatically increases error for the `sin` and `cos` functions by parenthesizing an expression the wrong way. You can see a more detailed exploration in https://github.com/IanBriggs/vdt_cos_error, but in short, in `sincos.h`, line 123 is:

    c = 1.0 - zz * .5 + zz * zz * get_cos_px(zz);

This adds `1.0` and `-zz * .5` together first, but it's more accurate to go from smallest to largest magnitude, like this:

    c = 1.0 + zz * (-.5 + zz * get_cos_px(zz));

This cuts the worst case error approximately in half for `fast_cos` on the domain $[0, \frac{\pi}{2}]$.

Here's a plot of error values versus MPFR over this interval:
![Original_vs_Reordered_Absolute_Error](https://github.com/dpiparo/vdt/assets/2159992/8a726214-7e09-41c5-b9f7-d5f19e58b995)